### PR TITLE
Wait for

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # docre
 
-[![Build and Publish](https://github.com/lifeofguenter/docre/workflows/build%20and%20publish/badge.svg?branch=main)](https://github.com/lifeofguenter/docre/actions?query=branch%3Amain+workflow%3A%22build+and+publish%22)
+[![build and publish](https://github.com/lifeofguenter/docre/actions/workflows/build-and-publish.yml/badge.svg)](https://github.com/lifeofguenter/docre/actions/workflows/build-and-publish.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=lifeofguenter_docre&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=lifeofguenter_docre)
 [![Docker Pulls](https://img.shields.io/docker/pulls/lifeofguenter/docre?style=flat)](https://hub.docker.com/r/lifeofguenter/docre)
 
@@ -16,3 +16,5 @@ Sat 21 May 2022 10:12:00 AM CEST
 Sat 21 May 2022 10:13:00 AM CEST
 ...
 ```
+
+When receiving SIGINT or SIGTERM, _docre_ will wait up to 110 seconds for the current job to finish before exiting.


### PR DESCRIPTION
```
 CRONTAB="* * * * *" ./docre ~/test.sh
2024/07/26 19:39:00 Fri Jul 26 19:37:00 CEST 2024 - 81 - Fri Jul 26 19:39:00 CEST 2024
^C2024/07/26 19:39:11 Received signal: interrupt. Waiting for 125 seconds before exiting...
2024/07/26 19:40:00 Fri Jul 26 19:38:00 CEST 2024 - 83 - Fri Jul 26 19:40:00 CEST 2024
2024/07/26 19:41:00 Fri Jul 26 19:39:00 CEST 2024 - 85 - Fri Jul 26 19:41:00 CEST 2024
2024/07/26 19:41:16 Exiting now.
```