### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,5 +1,8 @@
 name: build and publish
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/lifeofguenter/docre/security/code-scanning/1](https://github.com/lifeofguenter/docre/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/build-and-publish.yml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
For this workflow, a safe minimal baseline is:

- `contents: read` (recommended minimum and sufficient for checkout/read operations)

This directly resolves the CodeQL finding without changing workflow behavior. If later steps (e.g., GoReleaser publishing GitHub releases) require elevated rights, those can be added explicitly afterward (for example `contents: write`) at job level or workflow level, but the immediate fix for the reported issue is to declare permissions explicitly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
